### PR TITLE
#7 make src optional

### DIFF
--- a/example/src/index.html
+++ b/example/src/index.html
@@ -10,6 +10,7 @@
     <h1>The following stuff comes from partials</h1>
     <vite-partial src="/partial/partial-2.html"   />
     <vite-partial src="partial.html" />
-    <vite-partial src="" />
+    <vite-partial/>
+    <vite-partial src=""/>
   </body>
 </html>

--- a/plugin/src/insertPartials/findPartialTag.test.ts
+++ b/plugin/src/insertPartials/findPartialTag.test.ts
@@ -22,9 +22,11 @@ describe('<vite-partial> parsing', () => {
     expect(()=>findPartialTag(html)).toThrowError(SyntaxError);
   })
 
-  it('Throws SyntaxError if there is no src attribute', ()=> {
-    const html = '<html><vite-partial/>';
-    expect(()=>findPartialTag(html)).toThrowError(SyntaxError);
+  it('Returns undefined src when src attribute is missing', ()=> {
+    const html = '<html><vite-partial/></html>';
+    const result = findPartialTag(html)
+    expect(result).toBeDefined();
+    expect(result?.src).toBeUndefined();
   })
 
 

--- a/plugin/src/insertPartials/findPartialTag.ts
+++ b/plugin/src/insertPartials/findPartialTag.ts
@@ -6,7 +6,7 @@
     the g after the regex mans global. Aka. look for all matches, not just the first one
     (?<name>regex) is a named group. It takes anything the regex in the parentathese matches, and makes it accessible on match.group["name"];
     [^chars] means anything except the chars
-    The y at the end makes it sticky. That means it will only look for a match at the exact location of regex.lastIndex
+    The y at the end makes it sticky. That means it will only look for a match at the exact location of regex.lastIndex (yes, regex are stateful in js, deal with it)
 */
 
 /**

--- a/plugin/src/insertPartials/transformIndexHtml.ts
+++ b/plugin/src/insertPartials/transformIndexHtml.ts
@@ -8,10 +8,10 @@ const transformIndexHtml: Plugin['transformIndexHtml'] = async (html, ctx) => {
   while (parseResult !== undefined) {
     const { startIndex, afterIndex, src } = parseResult
 
-    //If the src attribute is empty, just return the html with the <vite-partial> tag removed
-    if (src === '') {
+    //If the src attribute is empty or missing, just return the html with the <vite-partial> tag removed
+    if (!src || src === '') {
       console.warn(
-        `Warn: <vite-partial> tag at character ${startIndex} has an empty src="" attribute`
+        `Warn: <vite-partial> tag at character ${startIndex} has an empty or missing src="" attribute`
       )
       html = html.slice(0, startIndex) + html.slice(afterIndex)
       parseResult = findPartialTag(html) //Find the next Tag, if there is one;


### PR DESCRIPTION
Addresses #7 and made the src attribute on the <vite-partial> tag optional. Omitting it is (currently) treated as if it were empty, and just leads to the tag being removed without substitution.