### PR TITLE
#3 prevent circular insertion

### DIFF
--- a/plugin/__mocks__/fs/promises.ts
+++ b/plugin/__mocks__/fs/promises.ts
@@ -1,0 +1,33 @@
+//Must be before imports, because mock-definitions are hoisted
+async function mockFsRead (path: string): Promise<Buffer> {
+  switch (path) {
+    case '/simple.html': {
+      return Buffer.from('<h1>HelloWorld<h1>')
+    }
+
+    case '/with-partial.html': {
+      return Buffer.from('<p><vite-partial src="/simple.html"/></p>')
+    }
+
+    case '/subdirectory/with-relative-partial.html': {
+      return Buffer.from('<p><vite-partial src="./../simple.html"/></p>')
+    }
+
+    case '/subdirectory/with-absolute-partial.html': {
+      return Buffer.from('<p><vite-partial src="/simple.html"/></p>')
+    }
+
+    case '/root/index.html': {
+      return Buffer.from('<p><vite-partial src="/partial.html"/></p>')
+    }
+
+    case '/root/partial.html': {
+      return Buffer.from('<h1>HelloWorld<h1>')
+    }
+
+    default:
+      throw new Error('File not found')
+  }
+}
+
+export default { readFile: mockFsRead }

--- a/plugin/__mocks__/fs/promises.ts
+++ b/plugin/__mocks__/fs/promises.ts
@@ -25,6 +25,14 @@ async function mockFsRead (path: string): Promise<Buffer> {
       return Buffer.from('<h1>HelloWorld<h1>')
     }
 
+    case '/circular/first.html' : {
+      return Buffer.from('<h1><vite-partial src="/circular/second.html"/><h1>')
+    }
+
+    case '/circular/second.html' : {
+      return Buffer.from('<h1><vite-partial src="/circular/first.html"/><h1>')
+    }
+
     default:
       throw new Error('File not found')
   }

--- a/plugin/setupTests.ts
+++ b/plugin/setupTests.ts
@@ -1,0 +1,6 @@
+import { vi } from 'vitest'
+import fsPromisesMock from './__mocks__/fs/promises'
+
+vi.mock('fs/promises', async () => {
+  return fsPromisesMock;
+})

--- a/plugin/src/insertPartials/getPartialContent.test.ts
+++ b/plugin/src/insertPartials/getPartialContent.test.ts
@@ -1,83 +1,45 @@
-//Must be before imports, because mock-definitions are hoisted
-async function mockFsRead (path: string): Promise<Buffer> {
-  switch (path) {
-    case '/simple.html': {
-      return Buffer.from('<h1>HelloWorld<h1>')
-    }
-
-    case '/with-partial.html': {
-      return Buffer.from('<p><vite-partial src="/simple.html"/></p>')
-    }
-
-    case '/subdirectory/with-relative-partial.html': {
-      return Buffer.from('<p><vite-partial src="./../simple.html"/></p>')
-    }
-
-    case '/subdirectory/with-absolute-partial.html': {
-      return Buffer.from('<p><vite-partial src="/simple.html"/></p>')
-    }
-
-    case '/root/index.html' : {
-      return Buffer.from('<p><vite-partial src="/partial.html"/></p>')
-    }
-
-    case '/root/partial.html' : {
-      return Buffer.from('<h1>HelloWorld<h1>')
-    }
-
-    default:
-      throw new Error('File not found')
-  }
-}
-
 import getPartialContent from './getPartialContent'
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
 describe('Reading Partial Files', () => {
-  beforeAll(() => {
-    vi.mock('fs/promises', () => {
-      return { readFile: mockFsRead }
-    })
-  })
-
-  afterAll(() => {
+  afterEach(() => {
     vi.clearAllMocks()
   })
 
   it('Returns file contents if the path & file are valid', async () => {
-    expect(await getPartialContent('/simple.html', '/')).toBe(
+    expect(await getPartialContent('/simple.html', '/',[])).toBe(
       '<h1>HelloWorld<h1>'
     )
   })
 
   it('includes partials in the loaded partial', async () => {
-    expect(await getPartialContent('/with-partial.html', '/')).toBe(
+    expect(await getPartialContent('/with-partial.html', '/',[])).toBe(
       '<p><h1>HelloWorld<h1></p>'
     )
   })
 
   it('includes partials with relative paths in the loaded partial', async () => {
     expect(
-      await getPartialContent('/subdirectory/with-relative-partial.html', '/')
+      await getPartialContent('/subdirectory/with-relative-partial.html', '/',[])
     ).toBe('<p><h1>HelloWorld<h1></p>')
   })
 
   it('includes partials with absolute paths in the loaded partial', async () => {
     expect(
-      await getPartialContent('/subdirectory/with-absolute-partial.html', '/')
+      await getPartialContent('/subdirectory/with-absolute-partial.html', '/',[])
     ).toBe('<p><h1>HelloWorld<h1></p>')
   })
 
   it('resolved absolute partial paths relative to the given root', async () => {
     expect(
-      await getPartialContent('/root/index.html', '/root/')
+      await getPartialContent('/root/index.html', '/root/', [])
     ).toBe('<p><h1>HelloWorld<h1></p>')
   })
 
     
   it('Throws if the path is invalud', async () => {
     expect(async () => {
-      await getPartialContent('asdfxgchvjbnk', '/')
+      await getPartialContent('asdfxgchvjbnk', '/',[])
     }).rejects.toThrowError()
   })
 })

--- a/plugin/src/insertPartials/getPartialContent.test.ts
+++ b/plugin/src/insertPartials/getPartialContent.test.ts
@@ -37,7 +37,7 @@ describe('Reading Partial Files', () => {
   })
 
     
-  it('Throws if the path is invalud', async () => {
+  it('Throws if the path is invalid', async () => {
     expect(async () => {
       await getPartialContent('asdfxgchvjbnk', '/',[])
     }).rejects.toThrowError()

--- a/plugin/src/insertPartials/getPartialContent.ts
+++ b/plugin/src/insertPartials/getPartialContent.ts
@@ -7,12 +7,14 @@ import transformHtml from './transformHTML'
  *
  * @param path the filesystem path to the partial that needs to be inserted
  * @param serverRoot the root directory from which files are resolved. Necessary if the partial also inserts partials
+ * @param callstack an array of all the partial-includers that have lead to this point. Used to prevent circular insertion
  * 
  * @throws SyntaxError if the file tries to import any other partials
  */
 export default async function getPartialContent (
   filePath: string,
   serverRoot: string,
+  callstack: string[],
 ): Promise<string> {
   let html
 
@@ -23,6 +25,10 @@ export default async function getPartialContent (
     throw Error('Could not read partial at path ' + filePath)
   }
 
-  const transformedHTML = transformHtml(html, filePath, serverRoot);
+  if(callstack.includes(filePath)) {
+    throw SyntaxError(`Circular insertion detected in file ${filePath}. Followed following insertion order: ${JSON.stringify(callstack)}`)
+  }
+
+  const transformedHTML = transformHtml(html, filePath, serverRoot, [...callstack, filePath]);
   return transformedHTML;
 }

--- a/plugin/src/insertPartials/transformHTML.test.ts
+++ b/plugin/src/insertPartials/transformHTML.test.ts
@@ -1,0 +1,9 @@
+import {describe, it, expect, afterEach} from 'vitest';
+import transformHTML from './transformHTML'
+
+describe("transform html", ()=>{
+    it("Throws when circular insertion", async()=>{
+        const html = '<vite-partial src="/circular/first.html"/>'
+        expect(async()=>{await transformHTML(html, "/circular/start.html", "/")}).rejects.toThrowError(SyntaxError)
+    })
+})

--- a/plugin/src/insertPartials/transformHTML.ts
+++ b/plugin/src/insertPartials/transformHTML.ts
@@ -1,9 +1,18 @@
-import { Plugin } from 'vite'
 import resolvePartialPath from './resolvePartialPath'
 import findPartialTag from './findPartialTag'
 import getPartialContent from './getPartialContent'
 
-const transformHtml = async (html: string, filePath: string, serverRoot: string) => {
+/**
+ * Finds all the <vite-partial> tags in the html string, and includes them. This is called recursiveley if those partials also include partials
+ * 
+ * @param html the html string
+ * @param filePath the absolute path of the html file being transformed
+ * @param serverRoot the vite server root from which absolute imports are resolved
+ * @param callstack an array of all the already included partials. Used to prevent circular insertion
+ * @returns html string with partials inserted
+ * @throws
+ */
+const transformHtml = async (html: string, filePath: string, serverRoot: string, callstack : string[] = []) => {
   let parseResult = findPartialTag(html)
   while (parseResult !== undefined) {
     const { startIndex, afterIndex, src } = parseResult
@@ -19,7 +28,7 @@ const transformHtml = async (html: string, filePath: string, serverRoot: string)
     }
 
     const path = await resolvePartialPath(src, filePath, serverRoot)
-    const partialContent = await getPartialContent(path, serverRoot);
+    const partialContent = await getPartialContent(path, serverRoot, callstack);
 
     //Insert the content into the html, replacing the <vite-partial> tag 
     html = html.slice(0, startIndex) + partialContent + html.slice(afterIndex)

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -100,6 +100,9 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
+  "include": [
+    "src/*"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/plugin/vite.config.ts
+++ b/plugin/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => {
+  return {
+    test: {
+      environment: 'node',
+      globals: true,
+      setupFiles: ['./setupTests.ts'],
+    },
+  };
+});


### PR DESCRIPTION
Prevents circular insertion by keeping track of which partials a given partial is being called from. If any of them are itself, it throws a SyntaxError and informs the user.